### PR TITLE
Add support for dialog display param

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ application:
         res.redirect('/');
       });
 
+##### Display Mode
+
+Set `display` in `passport.authenticate()` options to specify display
+mode. Refer to the [OAuth dialog
+documentation](https://developers.facebook.com/docs/reference/dialogs/oauth/)
+for information on its usage. 
+
+    app.get('/auth/facebook',
+      passport.authenticate('facebook', { display: 'mobile' }),
+      function(req, res){
+        // ...
+      });
+
 #### Extended Permissions
 
 If you need extended permissions from the user, the permissions can be requested

--- a/lib/passport-facebook/strategy.js
+++ b/lib/passport-facebook/strategy.js
@@ -55,6 +55,26 @@ function Strategy(options, verify) {
  */
 util.inherits(Strategy, OAuth2Strategy);
 
+/**
+ * Return extra parameters to be included in the authorization request.
+ *
+ * Options:
+ *  - `display`  Display mode to render dialog, { `page`, `popup`, `touch` }.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function (options) {
+  var params = {},
+      display = options.display;
+
+  if (display) {
+    params['display'] = display;
+  }
+
+  return params;
+};
 
 /**
  * Retrieve user profile from Facebook.

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -1,6 +1,7 @@
 var vows = require('vows');
 var assert = require('assert');
 var util = require('util');
+var urlLib = require('url');
 var FacebookStrategy = require('passport-facebook/strategy');
 
 
@@ -20,6 +21,64 @@ vows.describe('FacebookStrategy').addBatch({
     },
   },
   
+  'strategy when loading authorization url': {
+    topic: function () {
+      var strategy = new FacebookStrategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      });
+
+      return strategy;
+    },
+
+    'and display not set': {
+      topic: function (strategy) {
+        var mockRequest = {},
+            url;
+
+        // Stub strategy.redirect()
+        strategy.redirect = function (location) {
+          url = location;
+
+          return location;
+        };
+        strategy.authenticate(mockRequest);
+
+        return url;
+      },
+
+      'does not set authorization param': function(url) {
+        var params = urlLib.parse(url, true).query;
+
+        assert.isUndefined(params.display);
+      }
+    },
+
+    'and display set to mobile': {
+      topic: function (strategy) {
+        var mockRequest = {},
+            url;
+
+        // Stub strategy.redirect()
+        strategy.redirect = function (location) {
+          url = location;
+
+          return location;
+        };
+        strategy.authenticate(mockRequest, { display: 'mobile' });
+
+        return url;
+      },
+
+
+      'sets authorization param to mobile': function(url) {
+        var params = urlLib.parse(url, true).query;
+
+        assert.equal(params.display, 'mobile');
+      }
+    }
+  },
+
   'strategy when loading user profile': {
     topic: function() {
       var strategy = new FacebookStrategy({


### PR DESCRIPTION
https://developers.facebook.com/docs/reference/dialogs/oauth/

I'm not sure if this is the right place to file the issue. This may require upstream changes to `passport-oauth` in order to fix this elegantly. Figured it'd be best to run it by you before hacking away.
