### PR TITLE
fix redirect loop when facebook sends back an error_code (instead of just error)

### DIFF
--- a/lib/passport-facebook/strategy.js
+++ b/lib/passport-facebook/strategy.js
@@ -57,6 +57,20 @@ function Strategy(options, verify) {
  */
 util.inherits(Strategy, OAuth2Strategy);
 
+
+/**
+ * Override just because facebook might return error_code when the app is in sandbox.
+ * error_code is not part of OAuth2 spec, hence we do it here and not passport-oauth
+ */
+Strategy.prototype.authenticate = function(req, options) {
+  if (req.query && req.query.error_code) {
+    return this.fail({code: req.query.error_code, 
+                      message: req.query.error_message});
+  }
+
+  OAuth2Strategy.prototype.authenticate.call(this, req, options);
+};
+
 /**
  * Return extra Facebook-specific parameters to be included in the authorization
  * request.

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -369,5 +369,39 @@ vows.describe('FacebookStrategy').addBatch({
       },
     },
   },
+
+  'strategy when sending back an error_code': {
+    topic: function() {
+      var strategy = new FacebookStrategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret'
+      },
+      function() {});
+      
+      return strategy;
+    },
+    
+    'when error_code has value': {
+      topic: function(strategy) {
+        var self = this;
+        strategy.fail = function(info) {
+          self.callback(null, info);
+        }
+
+        process.nextTick(function () {
+          strategy.authenticate({ query: { error_code: 902, error_message: 'failure' }});
+        });
+      },
+
+      'should fail authentication' : function(err, info) {
+        // fail action was called, resulting in test callback
+        assert.isNull(err);
+      },
+      'should pass additional info' : function(err, info) {
+        assert.equal(info.message, 'failure');
+        assert.equal(info.code, 902);
+      },
+    },
+  },
   
 }).export(module);


### PR DESCRIPTION
Ultimately this is a bug on Facebook OAuth2 implementation. They should be using `error`, not `error_code`. Anyway, this generates a redirect loop because it is not handled by passport and returns a 302 that goes back to Facebook.

This was reported on passport-oauth (https://github.com/jaredhanson/passport-oauth/issues/16) but I think it should be fixed on facebook strategy because it's more related to facebook impl.

We discovered this bug because one of our customers was still on sandbox mode and tried with a non-developer account and got this error. So if you could push a new package on npm great, for now we'll point to our fork.
