### PR TITLE
Remove callback from the try/catch block

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -158,10 +158,11 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile._raw = body;
       profile._json = json;
 
-      done(null, profile);
     } catch (ex) {
-      done(new Error('Failed to parse user profile'));
+      return done(new Error('Failed to parse user profile'));
     }
+
+    done(null, profile);
   });
 };
 


### PR DESCRIPTION
Helps to debug if the callback defined by the user has errors (ie: trhows TypeError exceptions)
