### PR TITLE
Add possibility to fetch additional fields from Facebook.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -215,7 +215,9 @@ Strategy.prototype._convertProfileFields = function(profileFields) {
   var fields = [];
   
   profileFields.forEach(function(f) {
-    if (typeof map[f] === 'undefined') { return; }
+    // return raw Facebook profile field to support the many fields that don't
+    // map cleanly to Portable Contacts
+    if (typeof map[f] === 'undefined') { return fields.push(f); };
 
     if (Array.isArray(map[f])) {
       Array.prototype.push.apply(fields, map[f]);

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -147,6 +147,46 @@ describe('Strategy#userProfile', function() {
       });
     });
   });
+
+  describe('with profile fields not mapped from portable contacts schema', function() {
+    var strategy = new FacebookStrategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        profileFields: ['id', 'username', 'displayName', 'name', 'gender', 'profileUrl', 'emails', 'photos', 'updated_time']
+      },
+      function() {});
+
+      // mock
+      strategy._oauth2.get = function(url, accessToken, callback) {
+        if (url != 'https://graph.facebook.com/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture,updated_time') { return callback(new Error('incorrect url argument')); }
+        if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
+
+        var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com", "updated_time": "2013-11-02T18:33:09+0000"}';
+        callback(null, body, undefined);
+      }
+
+    describe('loading profile', function() {
+      var profile;
+
+      before(function(done) {
+        strategy.userProfile('token', function(err, p) {
+          if (err) { return done(err); }
+          profile = p;
+          done();
+        });
+      });
+
+      it('should parse profile', function() {
+        expect(profile.provider).to.equal('facebook');
+        expect(profile.id).to.equal('500308595');
+        expect(profile.username).to.equal('jaredhanson');
+      });
+
+      it('should have additional fields in profile._json', function() {
+        expect(profile._json.updated_time).to.equal('2013-11-02T18:33:09+0000');
+      });
+    });
+  });
   
   describe('with profile fields mapped from portable contacts schema and proof enabled', function() {
     var strategy = new FacebookStrategy({


### PR DESCRIPTION
The Facebook plugin currently only allows do fetch fields defined in the strategy. This change will just pass fields it doesn't know to the facebook url. Before these were removed.

The LinkedIn plugin allows to fetch additional fields too.
