### PR TITLE
Getting Facebook Picture in 'normal' size that is not the default size

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -209,7 +209,7 @@ Strategy.prototype._convertProfileFields = function(profileFields) {
     'gender':      'gender',
     'profileUrl':  'link',
     'emails':      'email',
-    'photos':      'picture'
+    'photos':      'picture.type(normal)'
   };
   
   var fields = [];


### PR DESCRIPTION
Pre-specified size of picture to normal size. The default size will be square (50x50) if you don't pre-specified it and it results small sometimes. Normal size is 100x100
