### PR TITLE
Update strategy.js to use Facebook API v2.0

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,15 +48,15 @@ var uri = require('url')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/dialog/oauth';
-  options.tokenURL = options.tokenURL || 'https://graph.facebook.com/oauth/access_token';
+  options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/v2.0/dialog/oauth';
+  options.tokenURL = options.tokenURL || 'https://graph.facebook.com/v2.0/oauth/access_token';
   options.scopeSeparator = options.scopeSeparator || ',';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'facebook';
   this._clientSecret = options.clientSecret;
   this._enableProof = options.enableProof;
-  this._profileURL = options.profileURL || 'https://graph.facebook.com/me';
+  this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.0/me';
   this._profileFields = options.profileFields || null;
 }
 


### PR DESCRIPTION
Facebook auth requests should use api v2.0 (as 'unversioned' 1.0 will be phased out)
https://developers.facebook.com/docs/apps/upgrading