### PR TITLE
Updated Facebook URLs to include API version (2.0).

### DIFF
--- a/examples/login/views/account.ejs
+++ b/examples/login/views/account.ejs
@@ -1,3 +1,2 @@
 <p>ID: <%= user.id %></p>
-<p>Username: <%= user.username %></p>
 <p>Name: <%= user.displayName %></p>

--- a/examples/login/views/index.ejs
+++ b/examples/login/views/index.ejs
@@ -1,5 +1,5 @@
 <% if (!user) { %>
 	<h2>Welcome! Please log in.</h2>
 <% } else { %>
-	<h2>Hello, <%= user.username %>.</h2>
+	<h2>Hello, <%= user.displayName %>.</h2>
 <% } %>

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -12,7 +12,6 @@ exports.parse = function(json) {
   
   var profile = {};
   profile.id = json.id;
-  profile.username = json.username;
   profile.displayName = json.name;
   profile.name = { familyName: json.last_name,
                    givenName: json.first_name,

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,15 +48,15 @@ var uri = require('url')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/dialog/oauth';
-  options.tokenURL = options.tokenURL || 'https://graph.facebook.com/oauth/access_token';
+  options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/v2.0/dialog/oauth';
+  options.tokenURL = options.tokenURL || 'https://graph.facebook.com/v2.0/oauth/access_token';
   options.scopeSeparator = options.scopeSeparator || ',';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'facebook';
   this._clientSecret = options.clientSecret;
   this._enableProof = options.enableProof;
-  this._profileURL = options.profileURL || 'https://graph.facebook.com/me';
+  this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.0/me';
   this._profileFields = options.profileFields || null;
 }
 
@@ -121,7 +121,6 @@ Strategy.prototype.authorizationParams = function (options) {
  *
  *   - `provider`         always set to `facebook`
  *   - `id`               the user's Facebook ID
- *   - `username`         the user's Facebook username
  *   - `displayName`      the user's full name
  *   - `name.familyName`  the user's last name
  *   - `name.givenName`   the user's first name
@@ -203,7 +202,6 @@ Strategy.prototype.parseErrorResponse = function(body, status) {
 Strategy.prototype._convertProfileFields = function(profileFields) {
   var map = {
     'id':          'id',
-    'username':    'username',
     'displayName': 'name',
     'name':       ['last_name', 'first_name', 'middle_name'],
     'gender':      'gender',

--- a/test/strategy.authorizationparams.test.js
+++ b/test/strategy.authorizationparams.test.js
@@ -28,7 +28,7 @@ describe('Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.facebook.com/dialog/oauth?display=mobile&response_type=code&redirect_uri=&client_id=ABC123');
+      expect(url).to.equal('https://www.facebook.com/v2.0/dialog/oauth?display=mobile&response_type=code&redirect_uri=&client_id=ABC123');
     });
   });
   
@@ -47,7 +47,7 @@ describe('Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://www.facebook.com/dialog/oauth?auth_type=reauthenticate&auth_nonce=foo123&response_type=code&redirect_uri=&client_id=ABC123');
+      expect(url).to.equal('https://www.facebook.com/v2.0/dialog/oauth?auth_type=reauthenticate&auth_nonce=foo123&response_type=code&redirect_uri=&client_id=ABC123');
     });
   });
   

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -16,10 +16,10 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
     
@@ -36,8 +36,8 @@ describe('Strategy#userProfile', function() {
     
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
     });
   });
@@ -46,16 +46,16 @@ describe('Strategy#userProfile', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
-        profileURL: 'https://graph.facebook.com/me?fields=id,username'
+        profileURL: 'https://graph.facebook.com/v2.0/me?fields=id,username'
       },
       function() {});
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me?fields=id,username') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me?fields=id,username') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
     
@@ -72,8 +72,8 @@ describe('Strategy#userProfile', function() {
     
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
     });
   });
@@ -82,17 +82,17 @@ describe('Strategy#userProfile', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
-        profileURL: 'https://graph.facebook.com/me?fields=id,username',
+        profileURL: 'https://graph.facebook.com/v2.0/me?fields=id,username',
         enableProof: true
       },
       function() {});
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me?fields=id,username&appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me?fields=id,username&appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
     
@@ -109,8 +109,8 @@ describe('Strategy#userProfile', function() {
     
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
     });
   });
@@ -125,10 +125,10 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
     
@@ -145,8 +145,8 @@ describe('Strategy#userProfile', function() {
     
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
     });
   });
@@ -161,10 +161,10 @@ describe('Strategy#userProfile', function() {
 
       // mock
       strategy._oauth2.get = function(url, accessToken, callback) {
-        if (url != 'https://graph.facebook.com/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture,updated_time') { return callback(new Error('incorrect url argument')); }
+        if (url != 'https://graph.facebook.com/v2.0/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture,updated_time') { return callback(new Error('incorrect url argument')); }
         if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
 
-        var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com", "updated_time": "2013-11-02T18:33:09+0000"}';
+        var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com", "updated_time": "2013-11-02T18:33:09+0000"}';
         callback(null, body, undefined);
       }
 
@@ -181,8 +181,8 @@ describe('Strategy#userProfile', function() {
 
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
 
       it('should have additional fields in profile._json', function() {
@@ -202,10 +202,10 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a&fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a&fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      var body = '{"id":"90184183272117575","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/90184183272117575","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
     
@@ -222,8 +222,8 @@ describe('Strategy#userProfile', function() {
     
       it('should parse profile', function() {
         expect(profile.provider).to.equal('facebook');
-        expect(profile.id).to.equal('500308595');
-        expect(profile.username).to.equal('jaredhanson');
+        expect(profile.id).to.equal('90184183272117575');
+        expect(profile.name.givenName).to.equal("Jared");
       });
     });
   });

--- a/test/strategy.profile.error.test.js
+++ b/test/strategy.profile.error.test.js
@@ -15,7 +15,7 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me') { return callback(new Error('wrong url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me') { return callback(new Error('wrong url argument')); }
       if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
     
       var body = '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190}}';
@@ -50,7 +50,7 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me') { return callback(new Error('wrong url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me') { return callback(new Error('wrong url argument')); }
       if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
     
       var body = '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190}}';
@@ -83,7 +83,7 @@ describe('Strategy#userProfile', function() {
   
     // mock
     strategy._oauth2.get = function(url, accessToken, callback) {
-      if (url != 'https://graph.facebook.com/me') { return callback(new Error('wrong url argument')); }
+      if (url != 'https://graph.facebook.com/v2.0/me') { return callback(new Error('wrong url argument')); }
       if (accessToken != 'token') { return callback(new Error('wrong token argument')); }
     
       var body = 'Hello, world.';

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -14,10 +14,10 @@ describe('Strategy#userProfile', function() {
   
   // mock
   strategy._oauth2.get = function(url, accessToken, callback) {
-    if (url != 'https://graph.facebook.com/me') { return callback(new Error('incorrect url argument')); }
+    if (url != 'https://graph.facebook.com/v2.0/me') { return callback(new Error('incorrect url argument')); }
     if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
     
-    var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+    var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"https:\\/\\/www.facebook.com\\/app_scoped_user_id\\/jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
     callback(null, body, undefined);
   };
     
@@ -36,12 +36,11 @@ describe('Strategy#userProfile', function() {
       expect(profile.provider).to.equal('facebook');
       
       expect(profile.id).to.equal('500308595');
-      expect(profile.username).to.equal('jaredhanson');
       expect(profile.displayName).to.equal('Jared Hanson');
       expect(profile.name.familyName).to.equal('Hanson');
       expect(profile.name.givenName).to.equal('Jared');
       expect(profile.gender).to.equal('male');
-      expect(profile.profileUrl).to.equal('http://www.facebook.com/jaredhanson');
+      expect(profile.profileUrl).to.equal('https://www.facebook.com/app_scoped_user_id/jaredhanson');
       expect(profile.emails).to.have.length(1);
       expect(profile.emails[0].value).to.equal('jaredhanson@example.com');
       expect(profile.photos).to.be.undefined;


### PR DESCRIPTION
Removed references to the 'username' field which is no longer returned.  Updated
tests to reflect app scoped IDs.

[Facebook API 2.0](https://developers.facebook.com/docs/apps/upgrading) seems to be making an effort to make uniquely identifiable information unavailable to apps (presumably to reduce user tracking and such.)  The [Business Mapping API](https://developers.facebook.com/docs/apps/for-business) has been introduced to allow user tracking between apps published by the same business.

All this to say, username is no longer returned, and user ids are scoped to the app.  I don't know what the effect is on Facebook emails that include the user id (if that's even possible) since my primary email address is not my Facebook email address (and Facebook doesn't give me the option to make it primary.)