### PR TITLE
Fixed issue where Facebook would not return all basic public profile information if no profile fields are specified

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,7 +57,7 @@ function Strategy(options, verify) {
   this._clientSecret = options.clientSecret;
   this._enableProof = options.enableProof;
   this._profileURL = options.profileURL || 'https://graph.facebook.com/me';
-  this._profileFields = options.profileFields || null;
+  this._profileFields = options.profileFields || ['id', 'displayName', 'name', 'gender', 'birthday', 'profileUrl', 'emails', 'photos', 'age_range', 'locale', 'location', 'timezone'];
 }
 
 /**
@@ -102,7 +102,7 @@ Strategy.prototype.authorizationParams = function (options) {
   if (options.display) {
     params.display = options.display;
   }
-  
+
   // https://developers.facebook.com/docs/facebook-login/reauthentication/
   if (options.authType) {
     params.auth_type = options.authType;
@@ -143,7 +143,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     // secret as the key.
     //
     // For further details, refer to:
-    // https://developers.facebook.com/docs/reference/api/securing-graph-api/    
+    // https://developers.facebook.com/docs/reference/api/securing-graph-api/
     var proof = crypto.createHmac('sha256', this._clientSecret).update(accessToken).digest('hex');
     url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + encodeURIComponent(proof);
   }
@@ -155,20 +155,20 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
   this._oauth2.get(url, accessToken, function (err, body, res) {
     var json;
-    
+
     if (err) {
       if (err.data) {
         try {
           json = JSON.parse(err.data);
         } catch (_) {}
       }
-      
+
       if (json && json.error && typeof json.error == 'object') {
         return done(new FacebookGraphAPIError(json.error.message, json.error.type, json.error.code, json.error.error_subcode));
       }
       return done(new InternalOAuthError('Failed to fetch user profile', err));
     }
-    
+
     try {
       json = JSON.parse(body);
     } catch (ex) {
@@ -212,9 +212,9 @@ Strategy.prototype._convertProfileFields = function(profileFields) {
     'emails':      'email',
     'photos':      'picture'
   };
-  
+
   var fields = [];
-  
+
   profileFields.forEach(function(f) {
     // return raw Facebook profile field to support the many fields that don't
     // map cleanly to Portable Contacts


### PR DESCRIPTION
With the new version 2.0 of [Facebook Login](https://developers.facebook.com/docs/apps/upgrading), requesting the basic profile scope from Facebook no longer seems to return the profile picture, age range, timezone, etc., even if those items are public. Adding things like `photos`, `age_range`, `timezone`, etc. to the `profileFields` parameter does return this data, but it's expected behavior that not specifying anything in `profileFields` should return all public profile data.

From my glancing at this, it appears that Facebook is in the wrong here by no longer returning all public profile data if no `fields` query string parameter is passed. There is actually a [bug open on this from January 28](https://developers.facebook.com/bugs/581729778568089/) and I pinged the thread to see if there was any resolution. In the end, Facebook returns what Facebook wants and that is causing a breaking change in `facebook-passport`. A solution would be to change:

```
this._profileFields = options.profileFields || null;
```

to something like:

```
this._profileFields = options.profileFields || ['id', 'displayName', 'name', 'gender', 'birthday', 'profileUrl', 'emails', 'photos', 'age_range', 'locale', 'location', 'timezone'];
```

but that feels pretty hacky. Maybe it is good enough for the time being. Any thoughts on how to handle this?