### PR TITLE
the example login app update with express 4.4.5 and now seperate middlewares

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -1,7 +1,12 @@
 var express = require('express')
   , passport = require('passport')
   , util = require('util')
-  , FacebookStrategy = require('passport-facebook').Strategy;
+  , FacebookStrategy = require('passport-facebook').Strategy
+  , logger = require('morgan')
+  , session = require('express-session')
+  , bodyParser = require("body-parser")
+  , cookieParser = require("cookie-parser")
+  , methodOverride = require('method-override');
 
 var FACEBOOK_APP_ID = "--insert-facebook-app-id-here--"
 var FACEBOOK_APP_SECRET = "--insert-facebook-app-secret-here--";
@@ -51,21 +56,18 @@ passport.use(new FacebookStrategy({
 var app = express();
 
 // configure Express
-app.configure(function() {
   app.set('views', __dirname + '/views');
   app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
+  app.use(logger());
+  app.use(cookieParser());
+  app.use(bodyParser());
+  app.use(methodOverride());
+  app.use(session({ secret: 'keyboard cat' }));
   // Initialize Passport!  Also use passport.session() middleware, to support
   // persistent login sessions (recommended).
   app.use(passport.initialize());
   app.use(passport.session());
-  app.use(app.router);
   app.use(express.static(__dirname + '/public'));
-});
 
 
 app.get('/', function(req, res){

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,8 +2,13 @@
   "name": "passport-facebook-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": "3.x",
+    "express": ">= 4.4.5",
     "ejs": ">= 0.0.0",
+    "body-parser": ">= 1.4.3",
+    "morgan": ">= 1.1.1",
+    "cookie-parser": ">= 1.3.2",
+    "method-override": ">= 2.0.2",
+    "express-session": ">= 1.6.1",
     "passport": ">= 0.0.0",
     "passport-facebook": ">= 0.0.0"
   }


### PR DESCRIPTION
Hi Jared.
Thanks for the awesome facebook plugin. I used it in my project. I just noticed that the example login app has an old version of express. As the new version uses separate middlewares, I've updated the example.

The changes are
- Removal of the deprecated app.configure() and app.use(app.router)
- Use now separate middleware modules, morgan, express-session, body-parser, cookie-parser, and method-override
