### PR TITLE
Fixed Typo in Layout.ejs example

### DIFF
--- a/examples/login/views/layout.ejs
+++ b/examples/login/views/layout.ejs
@@ -16,6 +16,5 @@
 			<a href="/logout">Log Out</a>
 			</p>
 		<% } %>
-		<%- body %>
 	</body>
 </html>


### PR DESCRIPTION
Deleted <%- body %> from line 19.  This is a typo.  The "<% %>" brackets escape to javascript, so this line causes a "body is undefined" error.   It was probably meant to read "</body>", but "</body>" already appears on the next line, so line 19 can simply be deleted.