### PR TITLE
Add docs for authType

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ checkins:
 Refer to Facebook's [docs](https://developers.facebook.com/docs/facebook-login/login-flow-for-web#re-asking-declined-permissions)
 
     app.get('/auth/facebook',
-      passport.authenticate('facebook', { authType: 'rerequest' }));
+      passport.authenticate('facebook', { authType: 'rerequest', scope: ['user_status', 'user_checkins'] }));
 
 #### Display Mode
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ checkins:
     app.get('/auth/facebook',
       passport.authenticate('facebook', { scope: ['user_status', 'user_checkins'] }));
 
+#### Re-asking for Declined Permissions
+
+Refer to Facebook's [docs](https://developers.facebook.com/docs/facebook-login/login-flow-for-web#re-asking-declined-permissions)
+
+    app.get('/auth/facebook',
+      passport.authenticate('facebook', { authType: 'rerequest' }));
+
 #### Display Mode
 
 The display mode with which to render the authorization dialog can be set by
@@ -78,6 +85,13 @@ documentation for more information.
 
     app.get('/auth/facebook',
       passport.authenticate('facebook', { display: 'touch' }));
+
+#### Re-authentication
+
+Refer to Facebook's [Re-authentication](https://developers.facebook.com/docs/facebook-login/reauthentication)
+
+    app.get('/auth/facebook',
+      passport.authenticate('facebook', { authType: 'reauthenticate', authNonce: 'foo123' }));
 
 #### Profile Fields
 


### PR DESCRIPTION
Provide some indication that the ability to activate the auth_type url parameter exists. I had to grep the source to figure out that passing the option auth_type (and not authType) was incorrect.

NOTE:
Could have added support for the option "auth_type" but I didn't know if that would have violated some design decision.