### PR TITLE
Add Graph API v2.4 support.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -57,7 +57,7 @@ function Strategy(options, verify) {
   this._clientSecret = options.clientSecret;
   this._enableProof = options.enableProof;
   this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.2/me';
-  this._profileFields = options.profileFields || null;
+  this._profileFields = options.profileFields || ['id', 'displayName', 'email'];
 }
 
 /**


### PR DESCRIPTION
Since Graph API v2.4, GET /me no longer returns email field as long as it's not explicitly requested.
See Graph API changelog for further information : https://developers.facebook.com/docs/apps/changelog