### PR TITLE
Add mappings for current location and hometown

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -218,7 +218,9 @@ Strategy.prototype._convertProfileFields = function(profileFields) {
     'birthday':    'birthday',
     'profileUrl':  'link',
     'emails':      'email',
-    'photos':      'picture'
+    'photos':      'picture',
+    'currentLocation': 'location',
+    'hometown':      'hometown'
   };
   
   var fields = [];


### PR DESCRIPTION
Facebook API can provide a user's current location
and hometown. However, to support this in
passport-facebook, we need mappings from
the Portable Contacts schema to Facebook's
own one.

This allows you to now include 'hometown'
and 'currentLocation' in the profileFields
array.