### PR TITLE
encodeURIComponent is redundant

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -143,7 +143,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     // For further details, refer to:
     // https://developers.facebook.com/docs/reference/api/securing-graph-api/    
     var proof = crypto.createHmac('sha256', this._clientSecret).update(accessToken).digest('hex');
-    url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + encodeURIComponent(proof);
+    url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + proof;
   }
   if (this._profileFields) {
     var fields = this._convertProfileFields(this._profileFields);


### PR DESCRIPTION
`proof` is `hex` encoded, and is URI safe. Remove redundant URI encoding attempt.