### PR TITLE
add state support

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -108,6 +108,10 @@ Strategy.prototype.authorizationParams = function (options) {
   if (options.authNonce) {
     params.auth_nonce = options.authNonce;
   }
+  //added state support
+  if (options.state) {
+    params.state = options.state;
+  }
 
   return params;
 };


### PR DESCRIPTION
This param is used for validation, in my case for identifying client id
https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#logindialog
so to use it simply add `req` param to callback function

```javascript
passport.use(new FacebookStrategy({
  clientID: CLIENT_ID,
  clientSecret: CLIENT_SECRET,
  callbackURL: CALLBACK_URL,
  passReqToCallback: true, //add this to get req
},
  ((req, accessToken, refreshToken, profile, done) => {
    const state = req.query.state;
    ...
```