### PR TITLE
Update to 2.6 API

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -53,7 +53,7 @@ function Strategy(options, verify) {
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'facebook';
-  this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.5/me';
+  this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.6/me';
   this._profileFields = options.profileFields || null;
   this._enableProof = options.enableProof;
   this._clientSecret = options.clientSecret;


### PR DESCRIPTION
Facebook's v2.5 API will go dark on 18 April 2018.   One lazy fix to forestall is to just jump over to v2.6.  Likely can go forward even more versions.  I've not had time to research that, however, as I'm about to go on vacation for several weeks and thus went with lazy/expedient.  This has been working in our production environment for the past several days.