### PR TITLE
Updated README file for 'reauthenticate' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ for further details.
 
 ##### How do I re-ask for for declined permissions?
 
-Set the `authType` option to `rerequest` when authenticating.
+Set the `authType` option to `reauthenticate` when authenticating.
 
 ```js
 app.get('/auth/facebook',
-  passport.authenticate('facebook', { authType: 'rerequest', scope: ['user_friends', 'manage_pages'] }));
+  passport.authenticate('facebook', { authType: 'reauthenticate', scope: ['user_friends', 'manage_pages'] }));
 ```
 
 Refer to [re-asking for declined permissions](https://developers.facebook.com/docs/facebook-login/web#re-asking-declined-permissions)


### PR DESCRIPTION
In Issue #125, someone mentioned {authType: "rerequest"} doesn't work anymore. Since I faced the same issue and found out it was changed to {authType: 'reauthenticate'}. 

Thus, I updated the README file in term someone who also need this feature for asking user's permission every time when user logged in.

Thanks for your contribution to this great package for us :)
Kevin