### PR TITLE
Adding locale in options constructor Strategy 

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,7 +48,7 @@ var OAuth2Strategy = require('passport-oauth2')
 function Strategy(options, verify) {
   options = options || {};
   var version = options.graphAPIVersion || 'v3.2';
-  
+
   options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/' + version + '/dialog/oauth';
   options.tokenURL = options.tokenURL || 'https://graph.facebook.com/' + version + '/oauth/access_token';
   options.scopeSeparator = options.scopeSeparator || ',';
@@ -59,6 +59,7 @@ function Strategy(options, verify) {
   this._profileFields = options.profileFields || null;
   this._enableProof = options.enableProof;
   this._clientSecret = options.clientSecret;
+  this._locale = options.locale || null;
 }
 
 // Inherit from `OAuth2Strategy`.
@@ -102,7 +103,7 @@ Strategy.prototype.authorizationParams = function (options) {
   if (options.display) {
     params.display = options.display;
   }
-  
+
   // https://developers.facebook.com/docs/facebook-login/reauthentication/
   if (options.authType) {
     params.auth_type = options.authType;
@@ -143,7 +144,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     // secret as the key.
     //
     // For further details, refer to:
-    // https://developers.facebook.com/docs/reference/api/securing-graph-api/    
+    // https://developers.facebook.com/docs/reference/api/securing-graph-api/
     var proof = crypto.createHmac('sha256', this._clientSecret).update(accessToken).digest('hex');
     url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + proof;
   }
@@ -151,24 +152,27 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     var fields = this._convertProfileFields(this._profileFields);
     if (fields !== '') { url.search = (url.search ? url.search + '&' : '') + 'fields=' + fields; }
   }
+  if (this._locale) {
+    url.search = (url.search ? url.search + '&' : '') + 'locale=' + this._locale;
+  }
   url = uri.format(url);
 
   this._oauth2.get(url, accessToken, function (err, body, res) {
     var json;
-    
+
     if (err) {
       if (err.data) {
         try {
           json = JSON.parse(err.data);
         } catch (_) {}
       }
-      
+
       if (json && json.error && typeof json.error == 'object') {
         return done(new FacebookGraphAPIError(json.error.message, json.error.type, json.error.code, json.error.error_subcode, json.error.fbtrace_id));
       }
       return done(new InternalOAuthError('Failed to fetch user profile', err));
     }
-    
+
     try {
       json = JSON.parse(body);
     } catch (ex) {
@@ -219,9 +223,9 @@ Strategy.prototype._convertProfileFields = function(profileFields) {
     'emails':      'email',
     'photos':      'picture'
   };
-  
+
   var fields = [];
-  
+
   profileFields.forEach(function(f) {
     // return raw Facebook profile field to support the many fields that don't
     // map cleanly to Portable Contacts

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -5,24 +5,24 @@ var FacebookStrategy = require('../lib/strategy');
 
 
 describe('Strategy#userProfile', function() {
-    
+
   describe('fetched from default endpoint', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret'
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v3.2/me') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-    
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -30,10 +30,10 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-    
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
-      
+
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
       expect(profile.displayName).to.equal('Jared Hanson');
@@ -45,34 +45,66 @@ describe('Strategy#userProfile', function() {
       expect(profile.emails[0].value).to.equal('jaredhanson@example.com');
       expect(profile.photos).to.be.undefined;
     });
-    
+
     it('should set raw property', function() {
       expect(profile._raw).to.be.a('string');
     });
-    
+
     it('should set json property', function() {
       expect(profile._json).to.be.an('object');
     });
   }); // fetched from default endpoint
-  
+
+  describe('fetched from default endpoint wih locale', function() {
+    var strategy = new FacebookStrategy({
+        clientID: 'ABC123',
+        clientSecret: 'secret',
+        locale: 'en_US'
+      }, function() {});
+
+    strategy._oauth2.get = function(url, accessToken, callback) {
+      if (url != 'https://graph.facebook.com/v3.2/me?locale=en_US') { return callback(new Error('incorrect url argument')); }
+      if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
+
+      var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
+      callback(null, body, undefined);
+    };
+
+    var profile;
+
+    before(function(done) {
+      strategy.userProfile('token', function(err, p) {
+        if (err) { return done(err); }
+        profile = p;
+        done();
+      });
+    });
+
+    it('should parse profile', function() {
+      expect(profile.provider).to.equal('facebook');
+      expect(profile.id).to.equal('500308595');
+      expect(profile.username).to.equal('jaredhanson');
+    });
+  }); // fetched from default endpoint with locale
+
   describe('fetched from default endpoint, with appsecret_proof', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
         enableProof: true
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v3.2/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
+
 
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -80,32 +112,32 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from default endpoint, with appsecret_proof
-  
+
   describe('fetched from default endpoint, with profile fields mapped from Portable Contacts schema', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
         profileFields: ['id', 'username', 'displayName', 'name', 'gender', 'profileUrl', 'emails', 'photos']
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v3.2/me?fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -113,14 +145,14 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from default endpoint, with profile fields mapped from Portable Contacts schema
-  
+
   describe('fetched from default endpoint, with profile fields mapped from Portable Contacts schema, with appsecret_proof', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
@@ -128,18 +160,18 @@ describe('Strategy#userProfile', function() {
         profileFields: ['id', 'username', 'displayName', 'name', 'gender', 'profileUrl', 'emails', 'photos'],
         enableProof: true
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v3.2/me?appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a&fields=id,username,name,last_name,first_name,middle_name,gender,link,email,picture') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -147,14 +179,14 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from default endpoint, with profile fields mapped from Portable Contacts schema, with appsecret_proof
-  
+
   describe('fetched from default endpoint, with profile fields a mix of mapped from Portable Contacts schema and native Facebook properties', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
@@ -191,25 +223,25 @@ describe('Strategy#userProfile', function() {
       expect(profile._json.updated_time).to.equal('2013-11-02T18:33:09+0000');
     });
   }); // fetched from default endpoint, with profile fields mapped from Portable Contacts schema
-  
+
   describe('fetched from default endpoint, with profile fields being an empty array', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
         profileFields: []
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v3.2/me') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -217,32 +249,32 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from default endpoint, with profile fields being an empty array
-  
+
   describe('fetched from older version with fields specified in URL', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret',
         profileURL: 'https://graph.facebook.com/v2.2/me?fields=id,username'
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v2.2/me?fields=id,username') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -250,14 +282,14 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from older version with fields specified in URL
-  
+
   describe('fetched from older version with fields specified in URL, with appsecret_proof', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
@@ -265,18 +297,18 @@ describe('Strategy#userProfile', function() {
         profileURL: 'https://graph.facebook.com/v2.2/me?fields=id,username',
         enableProof: true
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       if (url != 'https://graph.facebook.com/v2.2/me?fields=id,username&appsecret_proof=e941110e3d2bfe82621f0e3e1434730d7305d106c5f68c87165d0b27a4611a4a') { return callback(new Error('incorrect url argument')); }
       if (accessToken != 'token') { return callback(new Error('incorrect token argument')); }
-    
+
       var body = '{"id":"500308595","name":"Jared Hanson","first_name":"Jared","last_name":"Hanson","link":"http:\\/\\/www.facebook.com\\/jaredhanson","username":"jaredhanson","gender":"male","email":"jaredhanson\\u0040example.com"}';
       callback(null, body, undefined);
     };
-    
-    
+
+
     var profile;
-  
+
     before(function(done) {
       strategy.userProfile('token', function(err, p) {
         if (err) { return done(err); }
@@ -284,26 +316,26 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should parse profile', function() {
       expect(profile.provider).to.equal('facebook');
       expect(profile.id).to.equal('500308595');
       expect(profile.username).to.equal('jaredhanson');
     });
   }); // fetched from older version with fields specified in URL
-  
+
   describe('error caused by invalid token', function() {
     var strategy =  new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret'
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       var body = '{"error":{"message":"Invalid OAuth access token.","type":"OAuthException","code":190,"fbtrace_id":"XxXXXxXxX0x"}}';
-  
+
       callback({ statusCode: 400, data: body });
     };
-      
+
     var err, profile;
     before(function(done) {
       strategy.userProfile('token', function(e, p) {
@@ -312,7 +344,7 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('FacebookGraphAPIError');
@@ -323,21 +355,21 @@ describe('Strategy#userProfile', function() {
       expect(err.traceID).to.equal('XxXXXxXxX0x');
     });
   }); // error caused by invalid token
-  
+
   describe('error caused by malformed response', function() {
     var strategy =  new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret'
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       var body = 'Hello, world.';
       callback(null, body, undefined);
     };
-    
-      
+
+
     var err, profile;
-    
+
     before(function(done) {
       strategy.userProfile('token', function(e, p) {
         err = e;
@@ -345,26 +377,26 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-  
+
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.message).to.equal('Failed to parse user profile');
     });
   }); // error caused by malformed response
-  
+
   describe('internal error', function() {
     var strategy = new FacebookStrategy({
         clientID: 'ABC123',
         clientSecret: 'secret'
       }, function() {});
-  
+
     strategy._oauth2.get = function(url, accessToken, callback) {
       return callback(new Error('something went wrong'));
     }
-    
-    
+
+
     var err, profile;
-    
+
     before(function(done) {
       strategy.userProfile('wrong-token', function(e, p) {
         err = e;
@@ -372,7 +404,7 @@ describe('Strategy#userProfile', function() {
         done();
       });
     });
-    
+
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('InternalOAuthError');
@@ -380,10 +412,10 @@ describe('Strategy#userProfile', function() {
       expect(err.oauthError).to.be.an.instanceOf(Error);
       expect(err.oauthError.message).to.equal('something went wrong');
     });
-    
+
     it('should not load profile', function() {
       expect(profile).to.be.undefined;
     });
   }); // internal error
-  
+
 });


### PR DESCRIPTION
** READ THIS FIRST! **

#### Are you implementing a new feature?
A locale can be set in the options that will be used to build the url.
A defined locale makes user-liked page categories have a default language.

Requests for new features should first be discussed on the [developer forum](https://github.com/passport/develop).
This allows the community to gather feedback and assess whether or not there is
an existing way to achieve the desired functionality.

If it is determined that a new feature needs to be implemented, include a link
to the relevant discussion along with the pull request.

#### Is this a security patch?

Do not open pull requests that might have security implications.  Potential
security vulnerabilities should be reported privately to jaredhanson@gmail.com.
Once any vulerabilities have been repaired, the details will be disclosed
publicly in a responsible manner.  This also allows time for coordinating with
affected parties in order to mitigate negative consequences.


If neither of the above two scenarios apply to your situation, you should open
a pull request.  Delete this paragraph and the text above, and fill in the
information requested below.

<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-facebook/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
