### PR TITLE
Configure strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Facebook profile.  The `verify` callback must call `cb` providing a user to
 complete authentication.
 
 ```js
+const FacebookStrategy = require("passport-facebook").Strategy;
 passport.use(new FacebookStrategy({
     clientID: FACEBOOK_APP_ID,
     clientSecret: FACEBOOK_APP_SECRET,


### PR DESCRIPTION
without "const FacebookStrategy = require("passport-facebook").Strategy;" it gives an error. so it is required to configure a strategy.

